### PR TITLE
fix: setting rimraf version to work in lower node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "mkpath": ">=1.0.0",
     "xml2js": ">=0.4",
-    "rimraf": ">=2.4",
+    "rimraf": "3.0.2",
     "node-version-compare": ">=1.0.1",
     "plist": ">=1.2.0"
   },


### PR DESCRIPTION
After rimraf version 4 the node version required was greater than or equal to 14.14.0 and this was causing a problem in the build of projects that uses lower node versions.
https://www.npmjs.com/package/rimraf

![universal-link-rimraf-error-node-12](https://user-images.githubusercontent.com/50365361/214551307-a12e0a0a-55cf-466d-854c-6f1539ea3f7b.png)
